### PR TITLE
Add address submission to Submit.

### DIFF
--- a/api/interfaces/organisationPayload.ts
+++ b/api/interfaces/organisationPayload.ts
@@ -1,4 +1,4 @@
-export interface PostOrgansiationPayload {
+export interface OrganisationPayload {
     name: string,
     url?: string,
     superUser: {

--- a/api/interfaces/postOrgansiationPayload.ts
+++ b/api/interfaces/postOrgansiationPayload.ts
@@ -17,5 +17,17 @@ export interface PostOrgansiationPayload {
     dxAddress?: {
         dxExchange: string,
         dxNumber: string,
+    },
+    address: {
+        /**
+         * TODO: houseNoBuildingName should be optional on the api layer, currently it is
+         * required. Hence it is not optional here.
+         */
+        houseNoBuildingName: string,
+        addressLine1: string,
+        addressLine2?: string,
+        townCity: string,
+        county: string,
+        postcode: string,
     }
 }

--- a/api/interfaces/postOrgansiationPayload.ts
+++ b/api/interfaces/postOrgansiationPayload.ts
@@ -20,8 +20,8 @@ export interface PostOrgansiationPayload {
     },
     address: {
         /**
-         * TODO: houseNoBuildingName should be optional on the api layer, currently it is
-         * required. Hence it is not optional here.
+         * TODO: houseNoBuildingName should be optional, remove when it is.
+         * @see payloadBuilder.ts for descriptive comments.
          */
         houseNoBuildingName: string,
         addressLine1: string,

--- a/api/lib/payloadBuilder.spec.ts
+++ b/api/lib/payloadBuilder.spec.ts
@@ -66,6 +66,36 @@ describe('Payload builder', () => {
         expect(organsiationPayload.pbaAccounts[1].pbaNumber).to.equal(STATE_VALUES.PBAnumber2)
     })
 
+    it('Should take the office address one and set it as the addressLine1 on the payload.', () => {
+
+        const organsiationPayload = makeOrganisationPayload(STATE_VALUES)
+        expect(organsiationPayload.address.addressLine1).to.equal(STATE_VALUES.officeAddressOne)
+    })
+
+    it('Should take the office address two and set it as the addressLine2 on the payload.', () => {
+
+        const organsiationPayload = makeOrganisationPayload(STATE_VALUES)
+        expect(organsiationPayload.address.addressLine2).to.equal(STATE_VALUES.officeAddressTwo)
+    })
+
+    it('Should take the county and set it as the county on the payload.', () => {
+
+        const organsiationPayload = makeOrganisationPayload(STATE_VALUES)
+        expect(organsiationPayload.address.county).to.equal(STATE_VALUES.county)
+    })
+
+    it('Should take the postcode and set it as the postcode on the payload.', () => {
+
+        const organsiationPayload = makeOrganisationPayload(STATE_VALUES)
+        expect(organsiationPayload.address.postcode).to.equal(STATE_VALUES.postcode)
+    })
+
+    it('Should take the town or city and set it as the town city on the payload.', () => {
+
+        const organsiationPayload = makeOrganisationPayload(STATE_VALUES)
+        expect(organsiationPayload.address.townCity).to.equal(STATE_VALUES.townOrCity)
+    })
+
     xit('Should take the stored DX exchange field and set it as DX address, DX exchange on the payload.', () => {
 
         const organsiationPayload = makeOrganisationPayload(STATE_VALUES)

--- a/api/lib/payloadBuilder.ts
+++ b/api/lib/payloadBuilder.ts
@@ -1,4 +1,4 @@
-import {PostOrgansiationPayload} from '../interfaces/postOrgansiationPayload'
+import {OrganisationPayload} from '../interfaces/organisationPayload'
 
 /**
  * makeOrganisationPayload
@@ -15,7 +15,7 @@ import {PostOrgansiationPayload} from '../interfaces/postOrgansiationPayload'
  * @param stateValues
  * @return
  */
-export function makeOrganisationPayload(stateValues): PostOrgansiationPayload {
+export function makeOrganisationPayload(stateValues): OrganisationPayload {
     return {
         address: {
             addressLine1: stateValues.officeAddressOne,

--- a/api/lib/payloadBuilder.ts
+++ b/api/lib/payloadBuilder.ts
@@ -10,7 +10,7 @@ import {PostOrgansiationPayload} from '../interfaces/postOrgansiationPayload'
  *
  * TODO: houseNoBuildingName should not be an mandatory field on the api,
  * but an optional one. Hence it's currently an empty string, to prevent
- * a 500.
+ * a 500. JIRA ticket: PUID-111
  *
  * @param stateValues
  * @return

--- a/api/lib/payloadBuilder.ts
+++ b/api/lib/payloadBuilder.ts
@@ -1,4 +1,4 @@
-import {PostOrgansiationPayload} from "../interfaces/postOrgansiationPayload"
+import {PostOrgansiationPayload} from '../interfaces/postOrgansiationPayload'
 
 /**
  * makeOrganisationPayload
@@ -8,14 +8,23 @@ import {PostOrgansiationPayload} from "../interfaces/postOrgansiationPayload"
  * TODO: Note that if we add the dxAddress in, we get a 500 status error.
  * Fix required on the api. Awaiting fix. JIRA ticket raised: PUID-103
  *
- * TODO: Note that is we add the contacts in, we get a 500 status error
- * Fix required on api. Awaiting fix. JIRA ticket raised: PUID-104
+ * TODO: houseNoBuildingName should not be an mandatory field on the api,
+ * but an optional one. Hence it's currently an empty string, to prevent
+ * a 500.
  *
  * @param stateValues
  * @return
  */
 export function makeOrganisationPayload(stateValues): PostOrgansiationPayload {
     return {
+        address: {
+            addressLine1: stateValues.officeAddressOne,
+            addressLine2: stateValues.officeAddressTwo,
+            county: stateValues.county,
+            houseNoBuildingName: 'Remove property on api fix @see comments',
+            postcode: stateValues.postcode,
+            townCity: stateValues.townOrCity,
+        },
         name: stateValues.orgName,
         pbaAccounts: [
             {

--- a/api/services/rd-professional.ts
+++ b/api/services/rd-professional.ts
@@ -7,7 +7,8 @@ const logger = log4jui.getLogger('rd-professional')
 const url = config.services.rd_professional_api
 
 export async function postOrganisation(body: any): Promise<any> {
-  logger.info(`Post organisation body ${body}`)
+  logger.info(`Post organisation body`)
+  logger.debug(JSON.stringify(body))
   const response = await http.post(`${url}/organisations`, body)
   return response.data
 }


### PR DESCRIPTION
As adding an address to the POST payload now returns a 200. We've added the address to the payload, so that we can pass in Address Line 1, Address Line 2, County, Postcode, and Town or City to the api layer.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
